### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,18 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :basic_auth_enabled?
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
   def configure_permitted_parameters
-    added_attrs = [
-      :nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birth_date
-    ]
+    added_attrs = %i[nickname last_name first_name last_name_kana first_name_kana birth_date]
     devise_parameter_sanitizer.permit(:sign_up, keys: added_attrs)
+    # （任意）プロフィール編集画面を使うなら：
+    # devise_parameter_sanitizer.permit(:account_update, keys: added_attrs)
+  end
+
+  def basic_auth_enabled?
+    Rails.env.production? # 本番のみBasic認証を有効化
   end
 
   def basic_auth

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,14 +19,15 @@ class ItemsController < ApplicationController
     end
   end
 
-  def show
-  end
+  # def show   ← 商品詳細機能の実装時に使用
+  #   set_item
+  # end
 
   private
 
-  def set_item
-    @item = Item.find(params[:id])
-  end
+  # def set_item
+  #   @item = Item.find(params[:id])
+  # end
 
   def item_params
     params.require(:item).permit(

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: :show
 
   def index
-    # @items = Item.order(created_at: :desc) # 一覧機能の実装時にコメントを解除します
+    @items = Item.includes(image_attachment: :blob).order(created_at: :desc)
   end
 
   def new
@@ -18,14 +19,19 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  #   # @item = Item.find(params[:id]) # 詳細機能の実装時にコメントを解除します
-  # end
+  def show
+  end
 
   private
 
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
   def item_params
-    params.require(:item).permit(:image, :name, :info, :category_id, :sales_status_id, :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(
+      :image, :name, :info, :category_id, :sales_status_id,
+      :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price
+    ).merge(user_id: current_user.id)
   end
 end
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,2 @@
-module ItemsHelper
-  def postage_label(item)
-    case item.postage_burden # 例: enum :postage_burden, { seller: 0, buyer: 1 }
-    when "seller" then "送料込み(出品者負担)"
-    when "buyer"  then "着払い(購入者負担)"
-    else               "送料未設定"
-    end
-  end
+module ApplicationHelper
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
-module ApplicationHelper
+module ItemsHelper
+  def postage_label(item)
+    case item.postage_burden # 例: enum :postage_burden, { seller: 0, buyer: 1 }
+    when "seller" then "送料込み(出品者負担)"
+    when "buyer"  then "着払い(購入者負担)"
+    else               "送料未設定"
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,16 +12,16 @@ class User < ApplicationRecord
 
   # ← ここを英語の message に
   validates :last_name,
-           format: { with: ZENKAKU_REGEX,  message: 'is invalid. Input full-width characters' }
+            format: { with: ZENKAKU_REGEX,  message: 'is invalid. Input full-width characters' }
   validates :first_name,
-           format: { with: ZENKAKU_REGEX,  message: 'is invalid. Input full-width characters' }
+            format: { with: ZENKAKU_REGEX,  message: 'is invalid. Input full-width characters' }
   validates :last_name_kana,
-           format: { with: KATAKANA_REGEX, message: 'is invalid. Input full-width katakana characters' }
+            format: { with: KATAKANA_REGEX, message: 'is invalid. Input full-width katakana characters' }
   validates :first_name_kana,
-           format: { with: KATAKANA_REGEX, message: 'is invalid. Input full-width katakana characters' }
+            format: { with: KATAKANA_REGEX, message: 'is invalid. Input full-width katakana characters' }
 
   validates :password,
-           format: { with: PW_COMPLEXITY,
-                     message: 'is invalid. Include both letters and numbers' },
-           if: :password_required?
+            format: { with: PW_COMPLEXITY,
+                      message: 'is invalid. Include both letters and numbers' },
+            if: :password_required?
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to item_path(item) do %>
+            <a href="#">
               <div class='item-img-content'>
                 <%# 画像があれば表示、なければサンプル画像 %>
                 <% if item.image.attached? %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,64 +123,69 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <div class="subtitle" >
+    <div class="subtitle">
       新規投稿商品
     </div>
+
     <ul class='item-lists'>
+      <% if @items.present? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to item_path(item) do %>
+              <div class='item-img-content'>
+                <%# 画像があれば表示、なければサンプル画像 %>
+                <% if item.image.attached? %>
+                  <%= image_tag item.image, class: "item-img" %>
+                <% else %>
+                  <%= image_tag "item-sample.png", class: "item-img", alt: "no image" %>
+                <% end %>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+                <%# 購入機能実装後：売却済みならバッジ表示（今はコメントのまま残す） %>
+                <%# if item.sold_out? %>
+                <%#   <div class='sold-out'><span>Sold Out!!</span></div> %>
+                <%# end %>
+              </div>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+              <div class='item-info'>
+                <h3 class='item-name'><%= item.name %></h3>
+                <div class='item-price'>
+                  <span>
+                    <%= number_to_currency(item.price, unit: "¥", precision: 0) %><br>
+                    <%= item.shipping_fee_status&.name || "配送料未設定" %>
+                  </span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% else %>
+        <%# 商品がない場合のダミー表示 %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <div class='item-img-content'>
+              <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+            <div class='item-info'>
+              <h3 class='item-name'>商品を出品してね！</h3>
+              <div class='item-price'>
+                <span>9,999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>
+
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -172,7 +172,7 @@
             <div class='item-info'>
               <h3 class='item-name'>商品を出品してね！</h3>
               <div class='item-price'>
-                <span>9,999円<br>(税込み)</span>
+                <span>99999999円<br>(税込み)</span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :item do
     association :user
 
-    name  { "テスト商品" }
-    info  { "説明テキスト" }
+    name  { 'テスト商品' }
+    info  { '説明テキスト' }
 
     category_id            { 2 }
     sales_status_id        { 2 }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user do
     nickname              { Faker::Name.initials(number: 2) }
     sequence(:email)      { |n| "test#{n}@example.com" }
-    password              { '1a' + Faker::Internet.password(min_length: 6, mix_case: true) }
+    password              { "1a#{Faker::Internet.password(min_length: 6, mix_case: true)}" }
     password_confirmation { password }
     last_name             { '山田' }
     first_name            { '太郎' }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -41,31 +41,31 @@ RSpec.describe Item, type: :model do
       it 'category_idが1だと無効' do
         item.category_id = 1
         item.valid?
-        expect(item.errors.full_messages).to include("Category can't be blank").or include("Category must be other than 1")
+        expect(item.errors.full_messages).to include("Category can't be blank").or include('Category must be other than 1')
       end
 
       it 'sales_status_idが1だと無効' do
         item.sales_status_id = 1
         item.valid?
-        expect(item.errors.full_messages).to include("Sales status can't be blank").or include("Sales status must be other than 1")
+        expect(item.errors.full_messages).to include("Sales status can't be blank").or include('Sales status must be other than 1')
       end
 
       it 'shipping_fee_status_idが1だと無効' do
         item.shipping_fee_status_id = 1
         item.valid?
-        expect(item.errors.full_messages).to include("Shipping fee status can't be blank").or include("Shipping fee status must be other than 1")
+        expect(item.errors.full_messages).to include("Shipping fee status can't be blank").or include('Shipping fee status must be other than 1')
       end
 
       it 'prefecture_idが1だと無効' do
         item.prefecture_id = 1
         item.valid?
-        expect(item.errors.full_messages).to include("Prefecture can't be blank").or include("Prefecture must be other than 1")
+        expect(item.errors.full_messages).to include("Prefecture can't be blank").or include('Prefecture must be other than 1')
       end
 
       it 'scheduled_delivery_idが1だと無効' do
         item.scheduled_delivery_id = 1
         item.valid?
-        expect(item.errors.full_messages).to include("Scheduled delivery can't be blank").or include("Scheduled delivery must be other than 1")
+        expect(item.errors.full_messages).to include("Scheduled delivery can't be blank").or include('Scheduled delivery must be other than 1')
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 # Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,11 @@
 #
 # For more information, see https://rubydoc.info/gems/rspec-rails/RSpec/Rails
 
-ENV["RAILS_ENV"] ||= "test"
-require File.expand_path("../config/environment", __dir__)
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
-require "rspec/rails"
+abort('The Rails environment is running in production mode!') if Rails.env.production?
+require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -39,7 +39,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
-    Rails.root.join("spec/fixtures")
+    Rails.root.join('spec/fixtures')
   ]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
## What
- items#index を実装（新着順の一覧表示）
- 画像・商品名・価格・配送料の負担の4情報を表示
- 非ログインでも閲覧可
- 画像未添付時はプレースホルダ表示（リンク切れ防止）
- データ0件時はダミー商品を表示
- sold out バッジは購入機能実装後にON予定（クラスのみ事前定義）

## Why
- トップページで誰でも商品一覧を閲覧できるようにするため
- レビュー要件（並び順、4情報、ダミー表示、画像表示の安定化）に準拠

## 動作確認Gyazo
- 商品0件時のダミー表示：<https://gyazo.com/5986bd2d948eef24c83fa72143d2846c>
- 商品2件以上・新着順の表示：<https://gyazo.com/fc3aa0ce79e2cc497b4cbea0d9c9901c>

## その他
- Rubocop実行済み
