### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,15 +19,15 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show   ← 商品詳細機能の実装時に使用
-  #   set_item
-  # end
+  def show
+    # 表示専用。ロジックは持たない
+  end
 
   private
 
-  # def set_item
-  #   @item = Item.find(params[:id])
-  # end
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   def item_params
     params.require(:item).permit(

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,10 @@
 class ItemsController < ApplicationController
+  # 一覧・詳細は非ログインでも閲覧可
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: :show
 
   def index
+    # 新着順 + 画像のN+1回避
     @items = Item.includes(image_attachment: :blob).order(created_at: :desc)
   end
 
@@ -20,13 +22,14 @@ class ItemsController < ApplicationController
   end
 
   def show
-    # 表示専用。ロジックは持たない
+    # 表示専用（ロジックは持たない）
   end
 
   private
 
   def set_item
-    @item = Item.find(params[:id])
+    # 画像を事前読込しておく（ActiveStorageのN+1回避 & 画像表示の安定化）
+    @item = Item.with_attached_image.find(params[:id])
   end
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -120,71 +120,70 @@
   </div>
   <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
-  <div class='item-contents'>
-    <h2 class='title'>ピックアップカテゴリー</h2>
-    <div class="subtitle">
-      新規投稿商品
-    </div>
+<%# 商品一覧 %>
+<div class='item-contents'>
+  <h2 class='title'>ピックアップカテゴリー</h2>
+  <div class="subtitle">新規投稿商品</div>
 
-    <ul class='item-lists'>
-      <% if @items.present? %>
-        <% @items.each do |item| %>
-          <li class='list'>
-            <a href="#">
-              <div class='item-img-content'>
-                <%# 画像があれば表示、なければサンプル画像 %>
-                <% if item.image.attached? %>
-                  <%= image_tag item.image, class: "item-img" %>
-                <% else %>
-                  <%= image_tag "item-sample.png", class: "item-img", alt: "no image" %>
-                <% end %>
-
-                <%# 購入機能実装後：売却済みならバッジ表示（今はコメントのまま残す） %>
-                <%# if item.sold_out? %>
-                <%#   <div class='sold-out'><span>Sold Out!!</span></div> %>
-                <%# end %>
-              </div>
-
-              <div class='item-info'>
-                <h3 class='item-name'><%= item.name %></h3>
-                <div class='item-price'>
-                  <span>
-                    <%= number_to_currency(item.price, unit: "¥", precision: 0) %><br>
-                    <%= item.shipping_fee_status&.name || "配送料未設定" %>
-                  </span>
-                  <div class='star-btn'>
-                    <%= image_tag "star.png", class:"star-icon" %>
-                    <span class='star-count'>0</span>
-                  </div>
-                </div>
-              </div>
-            <% end %>
-          </li>
-        <% end %>
-      <% else %>
-        <%# 商品がない場合のダミー表示 %>
+  <ul class='item-lists'>
+    <% if @items.present? %>
+      <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to '#' do %>
+          <%= link_to item_path(item) do %>
             <div class='item-img-content'>
-              <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+              <%# 画像があれば表示、なければサンプル画像 %>
+              <% if item.image.attached? %>
+                <%= image_tag item.image, class: "item-img" %>
+              <% else %>
+                <%= image_tag "item-sample.png", class: "item-img", alt: "no image" %>
+              <% end %>
+
+              <%# 購入機能実装後：売却済みならバッジ表示（今はコメントのまま） %>
+              <%# if item.sold_out? %>
+              <%#   <div class='sold-out'><span>Sold Out!!</span></div> %>
+              <%# end %>
             </div>
+
             <div class='item-info'>
-              <h3 class='item-name'>商品を出品してね！</h3>
+              <h3 class='item-name'><%= item.name %></h3>
               <div class='item-price'>
-                <span>99999999円<br>(税込み)</span>
+                <span>
+                  <%= number_to_currency(item.price, unit: "¥", precision: 0) %><br>
+                  <%= item.shipping_fee_status&.name || "配送料未設定" %>
+                </span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>
                 </div>
               </div>
             </div>
-          <% end %>
+          <% end %> <%# ← link_to の end %>
         </li>
-      <% end %>
-    </ul>
-  </div>
-  <%# /商品一覧 %>
+      <% end %> <%# ← each の end %>
+    <% else %>
+      <%# 商品がない場合のダミー表示 %>
+      <li class='list'>
+        <%= link_to '#' do %>
+          <div class='item-img-content'>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          </div>
+          <div class='item-info'>
+            <h3 class='item-name'>商品を出品してね！</h3>
+            <div class='item-price'>
+              <span>9,999,999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </li>
+    <% end %> <%# ← if の end %>
+  </ul>
+</div>
+<%# /商品一覧 %>
+
 
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,192 +1,151 @@
-<%= render "shared/header" %>
 <div class='main'>
 
-  <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>
+  <%# 画面上部の「人生を変えるフリマアプリ」帯 %>
   <div class='title-contents'>
-    <h2 class='service-title'>
-      人生を変えるフリマアプリ
-    </h2>
-    <p class='service-explain'>
-      FURIMAはだれでもかんたんに出品・購入できる
-    </p>
-    <p class='service-explain'>
-      フリマアプリです
-    </p>
+    <h2 class='service-title'>人生を変えるフリマアプリ</h2>
+    <p class='service-explain'>FURIMAはだれでもかんたんに出品・購入できる</p>
+    <p class='service-explain'>フリマアプリです</p>
     <div class='store-btn'>
-      <%= link_to image_tag("app-store.svg", class:"apple-btn"), "#" %>
-      <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
+      <%= link_to image_tag("app-store.svg", class: "apple-btn"), "#" %>
+      <%= link_to image_tag("google-play.png", class: "google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面上部の「人生を変えるフリマアプリ」帯部分  %>
 
-  <%# FURIMAが選ばれる3つの理由部分 %>
+  <%# FURIMAが選ばれる3つの理由 %>
   <div class='select-reason-contents'>
-    <h2 class='title'>
-      FURIMAが選ばれる3つの理由
-    </h2>
+    <h2 class='title'>FURIMAが選ばれる3つの理由</h2>
     <ul class='reason-lists'>
       <li class='list'>
-        <%= image_tag "furima-intro01.png", class:"list-pict" %>
+        <%= image_tag "furima-intro01.png", class: "list-pict" %>
         <span class='reason-list-number'>1</span>
         <h3 class='reason-list-text'>
-          <span class='reason-list-blue-text'>3分</span>
-          ですぐに出品
+          <span class='reason-list-blue-text'>3分</span>ですぐに出品
         </h3>
-        <p class='reason-list-description'>
-          スマホで入力するだけで簡単に出品できる！
-        </p>
+        <p class='reason-list-description'>スマホで入力するだけで簡単に出品できる！</p>
       </li>
       <li class='list'>
-        <%= image_tag "furima-intro02.png", class:"list-pict" %>
+        <%= image_tag "furima-intro02.png", class: "list-pict" %>
         <span class='reason-list-number'>2</span>
         <h3 class='reason-list-text'>
-          <span class='reason-list-blue-text'>シンプル</span>
-          で使いやすい
+          <span class='reason-list-blue-text'>シンプル</span>で使いやすい
         </h3>
-        <p class='reason-list-description'>
-          めんどくさい入力は必要なく、検索も購入もスムーズ！
-        </p>
+        <p class='reason-list-description'>めんどくさい入力は必要なく、検索も購入もスムーズ！</p>
       </li>
       <li class='list'>
-        <%= image_tag "furima-intro03.png", class:"list-pict" %>
+        <%= image_tag "furima-intro03.png", class: "list-pict" %>
         <span class='reason-list-number'>3</span>
-        <h3 class='reason-list-text'>
-          手数料
-          <span class='reason-list-blue-text'>業界最安</span>
-        </h3>
-        <p class='reason-list-description'>
-          10%でお得に出品&購入！
-        </p>
+        <h3 class='reason-list-text'>手数料 <span class='reason-list-blue-text'>業界最安</span></h3>
+        <p class='reason-list-description'>10%でお得に出品&購入！</p>
       </li>
     </ul>
   </div>
-  <%# /FURIMAが選ばれる3つの理由部分 %>
 
-  <%# 画面中央の「会員数日本一位」帯部分 %>
+  <%# 画面中央の「会員数日本一位」帯 %>
   <div class='ad-contents'>
-    <h2 class='ad-title'>
-      会員数日本一位
-    </h2>
-    <p class='ad-explain'>
-      FURIMAは、フリマアプリで最も人気。
-    </p>
-    <p class='ad-explain'>
-      出品・購入回数も業界最多です！
-    </p>
-    <p class='ad-explain'>
-      ほしかったあの商品に出会えるかもしれません。
-    </p>
+    <h2 class='ad-title'>会員数日本一位</h2>
+    <p class='ad-explain'>FURIMAは、フリマアプリで最も人気。</p>
+    <p class='ad-explain'>出品・購入回数も業界最多です！</p>
+    <p class='ad-explain'>ほしかったあの商品に出会えるかもしれません。</p>
     <div class='store-btn'>
-      <%= link_to image_tag("app-store.svg", class:"apple-btn"), "#" %>
-      <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
+      <%= link_to image_tag("app-store.svg", class: "apple-btn"), "#" %>
+      <%= link_to image_tag("google-play.png", class: "google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面中央の「会員数日本一位」帯部分 %>
 
   <%# FURIMAの特徴 %>
   <div class='feature-contents'>
-    <h2 class='title'>
-      FURIMAの特徴
-    </h2>
+    <h2 class='title'>FURIMAの特徴</h2>
     <ul class='feature-lists'>
       <li class='list'>
-        <%= image_tag "furima-intro04.png", class:"list-pict" %>
-        <h3 class='feature-list-text'>
-          簡単に売り買いできる
-        </h3>
-        <p class='feature-list-description'>
-          スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
-        </p>
+        <%= image_tag "furima-intro04.png", class: "list-pict" %>
+        <h3 class='feature-list-text'>簡単に売り買いできる</h3>
+        <p class='feature-list-description'>スマホひとつで、いつでもどこでも簡単に出品・購入が可能！</p>
       </li>
       <li class='list'>
-        <%= image_tag "furima-intro05.png", class:"list-pict" %>
-        <h3 class='feature-list-text'>
-          売上金は即日振込みに対応
-        </h3>
-        <p class='feature-list-description'>
-          午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします。
-        </p>
+        <%= image_tag "furima-intro05.png", class: "list-pict" %>
+        <h3 class='feature-list-text'>売上金は即日振込みに対応</h3>
+        <p class='feature-list-description'>午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします。</p>
       </li>
       <li class='list'>
-        <%= image_tag "furima-intro06.png", class:"list-pict" %>
-        <h3 class='feature-list-text'>
-          様々な支払いに対応
-        </h3>
-        <p class='feature-list-description'>
-          お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
-        </p>
+        <%= image_tag "furima-intro06.png", class: "list-pict" %>
+        <h3 class='feature-list-text'>様々な支払いに対応</h3>
+        <p class='feature-list-description'>お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。</p>
       </li>
     </ul>
   </div>
-  <%# /FURIMAの特徴 %>
 
-<%# 商品一覧 %>
-<div class='item-contents'>
-  <h2 class='title'>ピックアップカテゴリー</h2>
-  <div class="subtitle">新規投稿商品</div>
+  <%# 商品一覧 %>
+  <div class='item-contents'>
+    <h2 class='title'>ピックアップカテゴリー</h2>
+    <div class="subtitle">新規投稿商品</div>
 
-  <ul class='item-lists'>
-    <% if @items.present? %>
-      <% @items.each do |item| %>
+    <ul class='item-lists'>
+      <% if @items.present? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to item_path(item) do %>
+              <div class='item-img-content'>
+                <% if item.image.attached? %>
+                  <%= image_tag item.image, class: "item-img" %>
+                <% else %>
+                  <%= image_tag "item-sample.png", class: "item-img", alt: "no image" %>
+                <% end %>
+                <%# ▼購入機能後にON
+                <%# if item.respond_to?(:order) && item.order.present? %>
+                <%#   <div class='sold-out'><span>Sold Out!!</span></div>
+                <%# end %>
+                
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'><%= item.name %></h3>
+                <div class='item-price'>
+                  <span>
+                    <%= number_to_currency(item.price, unit: "¥", precision: 0) %><br>
+                    <%= item.shipping_fee_status&.name.presence || "配送料未設定" %>
+                  </span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
+      <% else %>
         <li class='list'>
-          <%= link_to item_path(item) do %>
+          <%= link_to new_item_path do %>
             <div class='item-img-content'>
-              <%# 画像があれば表示、なければサンプル画像 %>
-              <% if item.image.attached? %>
-                <%= image_tag item.image, class: "item-img" %>
-              <% else %>
-                <%= image_tag "item-sample.png", class: "item-img", alt: "no image" %>
-              <% end %>
-
-              <%# 購入機能実装後：売却済みならバッジ表示（今はコメントのまま） %>
-              <%# if item.sold_out? %>
-              <%#   <div class='sold-out'><span>Sold Out!!</span></div> %>
-              <%# end %>
+              <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
             </div>
-
             <div class='item-info'>
-              <h3 class='item-name'><%= item.name %></h3>
+              <h3 class='item-name'>商品を出品してね！</h3>
               <div class='item-price'>
-                <span>
-                  <%= number_to_currency(item.price, unit: "¥", precision: 0) %><br>
-                  <%= item.shipping_fee_status&.name || "配送料未設定" %>
-                </span>
+                <span>9,999,999円<br>(税込み)</span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>
                 </div>
               </div>
             </div>
-          <% end %> <%# ← link_to の end %>
+          <% end %>
         </li>
-      <% end %> <%# ← each の end %>
-    <% else %>
-      <%# 商品がない場合のダミー表示 %>
-      <li class='list'>
-        <%= link_to '#' do %>
-          <div class='item-img-content'>
-            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-          </div>
-          <div class='item-info'>
-            <h3 class='item-name'>商品を出品してね！</h3>
-            <div class='item-price'>
-              <span>9,999,999円<br>(税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      </li>
-    <% end %> <%# ← if の end %>
-  </ul>
-</div>
-<%# /商品一覧 %>
+      <% end %>
+    </ul>
+  </div>
 
-
+  <%# ダウンロード誘導帯（見本の最下部の広告帯） %>
+  <div class='ad-footer-contents'>
+    <p class='ad-footer-explain'>だれでもかんたん、人生を変えるフリマアプリ</p>
+    <h2 class='ad-footer-title'>今すぐ無料ダウンロード！</h2>
+    <div class='store-btn'>
+      <%= link_to image_tag("app-store.svg", class: "apple-btn"), "#" %>
+      <%= link_to image_tag("google-play.png", class: "google-btn"), "#" %>
+    </div>
+  </div>
 </div>
-<%= link_to(new_item_path, class: 'purchase-btn') do %>
+
+<%= link_to new_item_path, class: 'purchase-btn' do %>
   <span class='purchase-btn-text'>出品する</span>
-  <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
+  <%= image_tag 'icon_camera.png', size: '185x50', class: "purchase-btn-icon" %>
 <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,8 +1,4 @@
 <div class="items-sell-contents">
-  <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), root_path %>
-  </header>
-
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
 
@@ -138,4 +134,9 @@
       </div>
     <% end %>
   </div>
-</div> 
+</div>
+
+<%# 出品ページは second-footer を表示する %>
+<% content_for :footer do %>
+  <%= render "shared/second-footer" %>
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,111 +1,52 @@
-<%= render "shared/header" %>
-
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
-    <h2 class="name">
-      <%= "商品名" %>
-    </h2>
-    <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    <h2 class="name"><%= @item.name %></h2>
+
+    <div class='item-img-content'>
+      <% if @item.image.attached? %>
+        <%= image_tag @item.image, class: "item-box-img" %>
+      <% else %>
+        <%= image_tag "placeholder.png", class: "item-box-img", alt: "no image" %>
+      <% end %>
     </div>
+
     <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
+      <span class="item-price"><%= number_to_currency(@item.price, unit: "¥", precision: 0, format: "%u %n") %></span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= (@item.respond_to?(:shipping_fee_status) && @item.shipping_fee_status&.name).presence ||
+            ShippingFeeStatus.find_by(id: @item.shipping_fee_status_id)&.name || "配送料未設定" %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <%= simple_format(@item.info) %>
     </div>
+
     <table class="detail-table">
       <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
+        <tr><th class="detail-item">出品者</th><td class="detail-value"><%= @item.user&.nickname || "不明" %></td></tr>
+        <tr><th class="detail-item">カテゴリー</th><td class="detail-value"><%= @item.category&.name || "未設定" %></td></tr>
+        <tr><th class="detail-item">商品の状態</th><td class="detail-value"><%= @item.sales_status&.name || "未設定" %></td></tr>
+        <tr><th class="detail-item">配送料の負担</th><td class="detail-value"><%= @item.shipping_fee_status&.name || "未設定" %></td></tr>
+        <tr><th class="detail-item">発送元の地域</th><td class="detail-value"><%= @item.prefecture&.name || "未設定" %></td></tr>
+        <tr><th class="detail-item">発送日の目安</th><td class="detail-value"><%= @item.scheduled_delivery&.name || "未設定" %></td></tr>
       </tbody>
     </table>
+
     <div class="option">
-      <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
-      </div>
-      <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
-        <span>不適切な商品の通報</span>
-      </div>
+      <div class="favorite-btn"><span>お気に入り 0</span></div>
+      <div class="report-btn"><span>不適切な商品の通報</span></div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>
       <textarea class="comment-text"></textarea>
       <p class="comment-warn">
-        相手のことを考え丁寧なコメントを心がけましょう。
-        <br>
+        相手のことを考え丁寧なコメントを心がけましょう。<br>
         不快な言葉遣いなどは利用制限や退会処分となることがあります。
       </p>
-      <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
-      </button>
+      <button type="button" class="comment-btn"><span>コメントする</span></button>
     </form>
   </div>
-  <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
-  </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
-
-<%= render "shared/footer" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,23 @@
   </head>
 
   <body>
-    <!-- ヘッダー（全ページで1回だけ描画） -->
-    <%= render "shared/header" %>
+    <%# --- ヘッダー --- %>
+    <% if content_for?(:header) %>
+      <%= yield :header %>
+    <% elsif controller_name == "items" && action_name == "new" %>
+      <%= render "shared/second-header" %> <%# ← new だけセカンドヘッダー %>
+    <% else %>
+      <%= render "shared/header" %>
+    <% end %>
 
-    <!-- コンテンツ -->
+    <%# --- コンテンツ本体 --- %>
     <%= yield %>
 
-    <!-- フッター（全ページで1回だけ描画） -->
-    <%= render "shared/footer" %>
+    <%# --- フッター --- %>
+    <% if content_for?(:footer) %>
+      <%= yield :footer %>           <%# ページ側が指定したらそれを使う %>
+    <% else %>
+      <%= render "shared/footer" %>  <%# それ以外は通常フッター %>
+    <% end %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,11 +10,14 @@
     <%= javascript_importmap_tags %>
   </head>
 
-<body>
-  <!-- コンテンツ表示 -->
-  <%= yield %>
+  <body>
+    <!-- ヘッダー（全ページで1回だけ描画） -->
+    <%= render "shared/header" %>
 
-  <!-- フッター -->
-  <%= render 'shared/second-footer' %>
-</body>
+    <!-- コンテンツ -->
+    <%= yield %>
+
+    <!-- フッター（全ページで1回だけ描画） -->
+    <%= render "shared/footer" %>
+  </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,45 +1,35 @@
-<%# 下部広告部分 %>
-<div class='ad-footer-contents'>
-  <p class='ad-footer-explain'>
-    だれでもかんたん、人生を変えるフリマアプリ
-  </p>
-  <h2 class='ad-footer-title'>
-    今すぐ無料ダウンロード！
-  </h2>
-  <div class='store-btn'>
-    <%= link_to image_tag("app-store.svg", class:"apple-btn"), "#" %>
-    <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
-  </div>
-</div>
-<%# /下部広告部分 %>
-
 <div class='footer'>
   <div class='footer-contents'>
     <div class='furima-details'>
       <h2 class='footer-content-head'>FURIMAについて</h2>
       <ul>
-        <li><%= link_to '会社概要（運営会社)', "#", class: "footer-link" %></li>
-        <li><%= link_to 'プライバシーポリシー', "#", class: "footer-link" %></li>
-        <li><%= link_to 'FURIMA利用規約', "#", class: "footer-link" %></li>
-        <li><%= link_to 'ポイントに関する特約', "#", class: "footer-link" %></li>
+        <li><a class="footer-link" href="#">会社概要（運営会社)</a></li>
+        <li><a class="footer-link" href="#">プライバシーポリシー</a></li>
+        <li><a class="footer-link" href="#">FURIMA利用規約</a></li>
+        <li><a class="footer-link" href="#">ポイントに関する特約</a></li>
       </ul>
     </div>
+
     <div class='furima-details'>
       <h2 class='footer-content-head'>FURIMAを見る</h2>
       <ul>
-        <li><%= link_to 'カテゴリー一覧', "#", class: "footer-link" %></li>
-        <li><%= link_to 'ブランド一覧', "#", class: "footer-link" %></li>
+        <li><a class="footer-link" href="#">カテゴリー一覧</a></li>
+        <li><a class="footer-link" href="#">ブランド一覧</a></li>
       </ul>
     </div>
+
     <div class='furima-details'>
       <h2 class='footer-content-head'>FURIMAについて</h2>
       <ul>
-        <li><%= link_to 'FURIMAガイド', "#", class: "footer-link" %></li>
-        <li><%= link_to 'FURIMAロゴ利用ガイドライン', "#", class: "footer-link" %></li>
-        <li><%= link_to 'お知らせ', "#", class: "footer-link" %></li>
+        <li><a class="footer-link" href="#">FURIMAガイド</a></li>
+        <li><a class="footer-link" href="#">FURIMAロゴ利用ガイドライン</a></li>
+        <li><a class="footer-link" href="#">お知らせ</a></li>
       </ul>
     </div>
   </div>
-  <%= link_to image_tag("furima-logo-white.png", class:"logo-white"), "#" %>
+
+  <%= link_to root_path do %>
+    <%= image_tag "furima-logo-white.png", class: "logo-white" %>
+  <% end %>
   <p>© FURIMA</p>
 </div>


### PR DESCRIPTION
## What
- トップページでフッターが二重に表示されていた問題を修正

## Why
- 共通レイアウト（application.html.erb）とindex.html.erbで両方にfooterを記述していたため
- レイアウト側に統一し、二重表示を防止するため

## Gyazo
- ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
  [https://gyazo.com/2244dd2182675e46df9c3df4a8f2f08d]

- ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
  [ →購入機能実装前のため不要？]

- ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画
  [ →購入機能実装前のため不要？]

- ログアウト状態で、商品詳細ページへ遷移した動画
  [https://gyazo.com/f6fd5cff9b5b5eeed417bd57992c22ce]